### PR TITLE
Refactor CLI to use `cli` library instead of `flag`

### DIFF
--- a/main.v
+++ b/main.v
@@ -295,7 +295,7 @@ fn main() {
 	mut app := cli.Command{
 		name:        'consolirepo'
 		description: 'Convert a repository into a single text file for language model processing'
-		version:     '0.1.0'
+		version:     '0.3.0'
 		posix_mode:  true
 		execute:     fn (cmd cli.Command) ! {
 			// Get flag values

--- a/main.v
+++ b/main.v
@@ -299,7 +299,7 @@ fn main() {
 		posix_mode:  true
 		execute:     fn (cmd cli.Command) ! {
 			// Get flag values
-			repo := cmd.flags.get_string('repo') or { '' }
+			repo := cmd.flags.get_string('repo')!
 			output := cmd.flags.get_string('output') or { '' }
 			extensions := cmd.flags.get_string('ext') or { '' }
 

--- a/main.v
+++ b/main.v
@@ -303,13 +303,6 @@ fn main() {
 			output := cmd.flags.get_string('output') or { '' }
 			extensions := cmd.flags.get_string('ext') or { '' }
 
-			// Validate required arguments
-			if repo == '' {
-				eprintln('Error: --repo is required')
-				println(cmd.help_message())
-				return
-			}
-
 			abs_repo := os.real_path(repo)
 			if !os.exists(abs_repo) {
 				eprintln('Error: ${abs_repo} does not exist')

--- a/main.v
+++ b/main.v
@@ -305,12 +305,10 @@ fn main() {
 
 			abs_repo := os.real_path(repo)
 			if !os.exists(abs_repo) {
-				eprintln('Error: ${abs_repo} does not exist')
-				return
+				return error('Error: ${abs_repo} does not exist')
 			}
 			if !os.is_dir(abs_repo) {
-				eprintln('Error: ${abs_repo} is not a directory')
-				return
+				return error('Error: ${abs_repo} is not a directory')
 			}
 
 			// Parse extensions if provided
@@ -321,8 +319,7 @@ fn main() {
 
 			mut runner := new_runner(abs_repo, output, ext_list)
 			runner.process() or {
-				eprintln('Processing failed: ${err}')
-				return
+				return error('Processing failed: ${err}')
 			}
 		}
 		flags: [

--- a/scripts/generate_assets_table.vsh
+++ b/scripts/generate_assets_table.vsh
@@ -44,7 +44,7 @@ fn main() {
 				flag:        .string
 				name:        'tag'
 				abbrev:      't'
-				description: 'Release tag (e.g. v0.1.0)'
+				description: 'Release tag (e.g. v0.3.0)'
 				required:    true
 			}
 		]

--- a/v.mod
+++ b/v.mod
@@ -1,7 +1,7 @@
 Module {
 	name: 'consolirepo'
 	description: 'Convert a repository into a single text file for LLM processing'
-	version: '0.1.0'
+	version: '0.3.0'
 	license: 'MIT'
 	dependencies: []
 }


### PR DESCRIPTION
- Migrate from using flag for parsing to the `cli` library for both the CLI app and the helping script, enhancing error handling and user experience while maintaining backward compatibility.
- Remove redundant checks and simplify flag handling.
- Update version to 0.3.0.